### PR TITLE
feat(docs): actualiza instrucciones de revisión de Pull Requests

### DIFF
--- a/.github/instructions/commit-messages.instructions.md
+++ b/.github/instructions/commit-messages.instructions.md
@@ -5,9 +5,9 @@ applyTo: '**/*'
 
 # Mensajes de Commit - Conventional Commits en Español
 
-## 🎯 Regla Obligatoria
+## 🎯 Regla de Oro
 
-**TODOS los mensajes de commit DEBEN seguir Conventional Commits y estar en español.**
+**TODOS los mensajes de commit DEBEN seguir Conventional Commits y estar en español. Sin embargo, esto no es bloqueante para la aprobación del PR, pero considere su uso para que, en el futuro, esto sea una REGLA OBLIGATORIA.**
 
 ## 📋 Formato Requerido
 

--- a/.github/instructions/pull-request-review.instructions.md
+++ b/.github/instructions/pull-request-review.instructions.md
@@ -9,6 +9,20 @@ applyTo: '**/*'
 
 Este archivo **DEBE** leerse y aplicarse al revisar **CUALQUIER** Pull Request antes de su aprobación.
 
+## 🛡️ Prioridad de Seguridad
+
+La **seguridad** debe ser la prioridad principal en la revisión de cualquier Pull Request. Ningún cambio que comprometa la seguridad será aceptado, aunque cumpla otros estándares.
+
+## 🏷️ Validación de Nombre de Rama
+
+Solo se aceptarán Pull Requests provenientes de ramas con nombres válidos siguiendo el patrón:
+
+- `feature/*`
+- `bugfix/*`
+- `hotfix/*`
+
+Si el nombre de la rama no cumple con estos prefijos, el PR debe ser rechazado.
+
 ## ❌ VALIDACIONES OBLIGATORIAS - RECHAZO AUTOMÁTICO
 
 Las siguientes condiciones **NUNCA** deben permitirse. Si se detectan, el PR **DEBE** ser rechazado:
@@ -138,6 +152,7 @@ const testEmployee = {
 Verificar que el código cumple con:
 
 - **Conventional Commits**: Mensajes de commit en español siguiendo el formato establecido
+- **Nota**: Si algún commit no cumple el estándar, debe informarse en la revisión, pero esto **no es bloqueante** para aprobar el PR.
 - **Autenticación**: Solo usar Clerk, nunca autenticación personalizada
 - **Componentes UI**: Solo shadcn/ui, no componentes personalizados
 - **Server Actions**: 
@@ -212,6 +227,8 @@ Antes de aprobar un PR, verificar:
 
 Cuando solicites cambios, sé específico y constructivo:
 
+**Recomendación:** Al proponer cambios, indica de manera resumida el cambio solicitado y explica brevemente el porqué. Esto facilita la comprensión y agiliza la revisión.
+
 ### ❌ Feedback Vago
 ```
 "Mejorar el código"
@@ -242,5 +259,7 @@ Un PR solo puede aprobarse cuando:
 4. ✅ Cumple con los estándares del proyecto
 5. ✅ El código es de calidad y está bien estructurado
 6. ✅ La funcionalidad fue probada
+
+7. ✅ El nombre de la rama es válido (feature/*, bugfix/*, hotfix/*)
 
 **RECUERDA**: Es mejor solicitar cambios que aprobar código que no cumpla con los estándares. La calidad y seguridad del código es responsabilidad de todos.

--- a/.github/instructions/pull-request-review.instructions.md
+++ b/.github/instructions/pull-request-review.instructions.md
@@ -13,16 +13,6 @@ Este archivo **DEBE** leerse y aplicarse al revisar **CUALQUIER** Pull Request a
 
 La **seguridad** debe ser la prioridad principal en la revisión de cualquier Pull Request. Ningún cambio que comprometa la seguridad será aceptado, aunque cumpla otros estándares.
 
-## 🏷️ Validación de Nombre de Rama
-
-Solo se aceptarán Pull Requests provenientes de ramas con nombres válidos siguiendo el patrón:
-
-- `feature/*`
-- `bugfix/*`
-- `hotfix/*`
-
-Si el nombre de la rama no cumple con estos prefijos, el PR debe ser rechazado.
-
 ## ❌ VALIDACIONES OBLIGATORIAS - RECHAZO AUTOMÁTICO
 
 Las siguientes condiciones **NUNCA** deben permitirse. Si se detectan, el PR **DEBE** ser rechazado:
@@ -259,7 +249,5 @@ Un PR solo puede aprobarse cuando:
 4. ✅ Cumple con los estándares del proyecto
 5. ✅ El código es de calidad y está bien estructurado
 6. ✅ La funcionalidad fue probada
-
-7. ✅ El nombre de la rama es válido (feature/*, bugfix/*, hotfix/*)
 
 **RECUERDA**: Es mejor solicitar cambios que aprobar código que no cumpla con los estándares. La calidad y seguridad del código es responsabilidad de todos.


### PR DESCRIPTION
Añade validación de nombre de rama, priorización explícita de seguridad, y aclara que los Conventional Commits deben informarse pero no bloquear el PR. También recomienda que el feedback sea resumido y justificado para facilitar la revisión.